### PR TITLE
Adding queryParams option

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,8 +3,8 @@
     "description": "Scrape google images",
     "type": "library",
     "require": {
-        "campo/random-user-agent": "^1.2",
-        "maciejczyzewski/bottomline": "^0.0.9"
+        "campo/random-user-agent": "^1.3",
+        "maciejczyzewski/bottomline": "^0.2.3"
     },
     "license": "MIT",
     "authors": [

--- a/spec/GoogleImageGrabber.spec.php
+++ b/spec/GoogleImageGrabber.spec.php
@@ -12,13 +12,45 @@ describe('GoogleImageGrabber', function ()
 			expect(count($images))->toBeGreaterThan(0);
 		});
 	});
-
-	describe('::grab($keyword, $proxy = "", $options = [], $queryParams = [])', function ()
+	// params URLs
+	describe('::getSearchURLParams($params)', function ()
 	{
-		it('Searching in a specific language (spanish)', function()
+		it('check sizes viables', function()
 		{
-                        $queryParams = ['hl' => 'es'];
-			$images = GoogleImageGrabber::grab('php en español', '', [], $queryParams);
+			$params = GoogleImageGrabber::getSearchURLParams([
+				'size' => 'small'
+			]);
+			expect($params)->toContainKey(['q', 'source', 'tbm', 'tbs']);
+			expect($params['tbs'])->toBe('isz:i');
+		});
+		it('Filter pornography, potentially offensive and inappropriate content', function()
+		{
+			$input = [
+				'keyword' => 'pretty woman',
+				'safe' => 'active'
+			];
+			$params = GoogleImageGrabber::getSearchURLParams($input);
+			expect($params)->toContainKey(['q', 'source', 'tbm', 'tbs', 'safe']);
+			expect($params['safe'])->toBe('active');
+		});
+		it('general testing', function()
+		{
+			$input = [
+				'keyword' => 'Logotipo PHP',
+				'locate' => 'es',
+				'license' => 'creative_commons',
+				'size' => 'small'
+			];
+			$params = GoogleImageGrabber::getSearchURLParams($input);
+			expect(isset($params['keyword']))->toBe(false);
+			expect(isset($params['q']))->toBe(true);
+			expect($params['q'])->toBe($input['keyword']);
+			// language
+			expect($params['hl'])->toBe('es');
+			// License and Size
+			expect($params['tbs'])->toBe('il:cl,isz:i');
+			// testing grab
+			$images = GoogleImageGrabber::grab($input);
 			expect(count($images))->toBeGreaterThan(0);
 		});
 	});

--- a/spec/GoogleImageGrabber.spec.php
+++ b/spec/GoogleImageGrabber.spec.php
@@ -12,4 +12,14 @@ describe('GoogleImageGrabber', function ()
 			expect(count($images))->toBeGreaterThan(0);
 		});
 	});
+
+	describe('::grab($keyword, $proxy = "", $options = [], $queryParams = [])', function ()
+	{
+		it('Searching in a specific language (spanish)', function()
+		{
+                        $queryParams = ['hl' => 'es'];
+			$images = GoogleImageGrabber::grab('php en español', '', [], $queryParams);
+			expect(count($images))->toBeGreaterThan(0);
+		});
+	});
 });

--- a/src/GoogleImageGrabber.php
+++ b/src/GoogleImageGrabber.php
@@ -57,12 +57,16 @@ class GoogleImageGrabber
         }
     }
 
-    public static function grab($keyword, $proxy = "", $options = [])
+    public static function grab($keyword, $proxy = "", $options = [], $queryParams = [])
     {
-        $url =
-            "https://www.google.com/search?q=" .
-            urlencode($keyword) .
-            "&source=lnms&tbm=isch&tbs=";
+        $defaultQueryParams = [
+            'q' => $keyword,
+            'source' => 'lnms',
+            'tbm' => 'isch',
+            'tbs' => ''
+        ];
+        $requestParams = array_merge($defaultQueryParams, $queryParams);
+        $url = "https://www.google.com/search?" . http_build_query($requestParams);
 
         $uas = [
             "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.182 Safari/537.36 Edg/88.0.705.68",


### PR DESCRIPTION
Hello,

I tried the project but when I did certain searches, sometimes I couldn't find results. When I reviewed the code, I realized that I should add the language in the URL, for this I added an option.

The other option I was thinking of is that the first argument `$keyword` can be an array or a string.
If it is an array it should contain the `q` (or `keywords`) attribute and could work like:

```php
$images = GoogleImageGrabber::grab([
    'q' => 'php en español',
    'hl' => 'es'
]);
```

If it is a string it will add this value as it does so far.

I don't know how you see this option or if it's fine like this, if these changes seem fine to you like this or if you want it to be modeled in another way.

What is your opinion?